### PR TITLE
docs: add seek helpers example

### DIFF
--- a/packages/oddysee/react/README.md
+++ b/packages/oddysee/react/README.md
@@ -235,7 +235,7 @@ export default function SeekControls() {
 }
 ```
 
-For simple one-off seeks, u can also use `controls.setCurrentTime(time)`. The `beginSeek`, `updateSeek`, and `commitSeek` helpers are useful when you want to coordinate a seek flow manually.
+For simple one-off seeks, you can also use `controls.setCurrentTime(time)`. The `beginSeek`, `updateSeek`, and `commitSeek` helpers are useful when you want to coordinate a seek flow manually.
 
 ### Deferred Seeking (Scrubber)
 

--- a/packages/oddysee/react/README.md
+++ b/packages/oddysee/react/README.md
@@ -235,7 +235,7 @@ export default function SeekControls() {
 }
 ```
 
-For simple one-off seeks, you can also use `controls.setCurrentTime(time)`. The `beginSeek`, `updateSeek`, and `commitSeek` helpers are useful when you want to coordinate a seek flow manually.
+For simple one-off seeks, u can also use `controls.setCurrentTime(time)`. The `beginSeek`, `updateSeek`, and `commitSeek` helpers are useful when you want to coordinate a seek flow manually.
 
 ### Deferred Seeking (Scrubber)
 

--- a/packages/oddysee/react/README.md
+++ b/packages/oddysee/react/README.md
@@ -198,8 +198,6 @@ export default function BasicPlayer() {
 Use the seek helpers when you need to move playback programmatically, such as skip forward/backward buttons or custom seek controls.
 
 ```tsx
-
-```
 import { useHlsAudioPlayer } from 'oddysee-react';
 
 export default function SeekControls() {
@@ -235,7 +233,9 @@ export default function SeekControls() {
     </div>
   );
 }
+```
 
+For simple one-off seeks, you can also use `controls.setCurrentTime(time)`. The `beginSeek`, `updateSeek`, and `commitSeek` helpers are useful when you want to coordinate a seek flow manually.
 ```tsx
 ### Deferred Seeking (Scrubber)
 

--- a/packages/oddysee/react/README.md
+++ b/packages/oddysee/react/README.md
@@ -193,7 +193,50 @@ export default function BasicPlayer() {
   );
 }
 ```
+### Seek Helpers
 
+Use the seek helpers when you need to move playback programmatically, such as skip forward/backward buttons or custom seek controls.
+
+```tsx
+
+```
+import { useHlsAudioPlayer } from 'oddysee-react';
+
+export default function SeekControls() {
+  const { state, controls, isLoading } = useHlsAudioPlayer({
+    src: { url: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8' },
+  });
+
+  const seekBy = (seconds: number) => {
+    const duration = state.duration ?? 0;
+    const nextTime = Math.min(
+      Math.max(state.currentTime + seconds, 0),
+      duration
+    );
+
+    controls.beginSeek();
+    controls.updateSeek(nextTime);
+    controls.commitSeek();
+  };
+
+  return (
+    <div className="seek-controls">
+      <button onClick={() => seekBy(-10)} disabled={isLoading}>
+        Back 10s
+      </button>
+
+      <span>
+        {state.currentTime.toFixed(0)}s / {state.duration?.toFixed(0) ?? '--'}s
+      </span>
+
+      <button onClick={() => seekBy(10)} disabled={isLoading}>
+        Forward 10s
+      </button>
+    </div>
+  );
+}
+
+```tsx
 ### Deferred Seeking (Scrubber)
 
 The hook provides a `scrub` object that wraps the three-phase seek model (`beginSeek` / `updateSeek` / `commitSeek`). This separates the user's drag gesture from the actual media seek so audio doesn't glitch while scrubbing.

--- a/packages/oddysee/react/README.md
+++ b/packages/oddysee/react/README.md
@@ -236,7 +236,7 @@ export default function SeekControls() {
 ```
 
 For simple one-off seeks, you can also use `controls.setCurrentTime(time)`. The `beginSeek`, `updateSeek`, and `commitSeek` helpers are useful when you want to coordinate a seek flow manually.
-```tsx
+
 ### Deferred Seeking (Scrubber)
 
 The hook provides a `scrub` object that wraps the three-phase seek model (`beginSeek` / `updateSeek` / `commitSeek`). This separates the user's drag gesture from the actual media seek so audio doesn't glitch while scrubbing.


### PR DESCRIPTION
## Summary

Adds a documentation example showing how to use the seek helpers for skip forward/backward controls.

## Related issue

Closes #31

## Type of Change

- Documentation update

## Testing

- Documentation-only change; no runtime testing required.